### PR TITLE
Refactor code to adhere to modern .Net conventions

### DIFF
--- a/Helpers classes/Chart.cs
+++ b/Helpers classes/Chart.cs
@@ -10,12 +10,6 @@ namespace SeaChart {
 
         //Private members
         //cf. public properties for documentationa about them
-        private string name;
-        private Image image;
-        private int xWidth, yHeight;
-        private int xZero, yZero ;
-        private int xStart, xCenter, xEnd;
-        private int yStart, yCenter, yEnd;
         private List<int> map;
 
         #region Chart main properties
@@ -23,37 +17,37 @@ namespace SeaChart {
         /// Gets or sets the chart name.
         /// </summary>
         /// <value>The chart name.</value>
-        public string Name { get { return name; } set { name = value; } }
+        public string Name { get; set; }
 
         /// <summary>
         /// Gets or sets the chart image.
         /// </summary>
         /// <value>The chart image.</value>
-        public Image Image { get { return image; } set { image = value; } }
+        public Image Image { get; set; }
 
         /// <summary>
         /// Gets or sets the width of the map in the game.
         /// </summary>
         /// <value>The width of the map.</value>
-        public int XWidth { get { return xWidth; } set { xWidth = value; } }
+        public int XWidth { get; set; }
 
         /// <summary>
         /// Gets or sets the height of the map in the game.
         /// </summary>
         /// <value>The height of the map.</value>
-        public int YHeight { get { return yHeight; } set { yHeight = value; } }
+        public int YHeight { get; set; }
 
         /// <summary>
         /// Gets or sets the 0° point X coordinate in the game.
         /// </summary>
         /// <value>The 0° point X coordinate.</value>
-        public int XZero { get { return xZero; } set { xZero = value; } }
+        public int XZero { get; set; }
 
         /// <summary>
         /// Gets or sets the 0° point Y coordinate in the game
         /// </summary>
         /// <value>The 0° point Y  coordinate.</value>
-        public int YZero { get { return yZero; } set { yZero = value; } }
+        public int YZero { get; set; }
 
         /// <summary>
         /// Gets or sets the UO map id.
@@ -69,33 +63,38 @@ namespace SeaChart {
         /// Gets or sets the horizontal left start coordinate.
         /// </summary>
         /// <value>The X start coordinate.</value>
-        public int XStart { get { return xStart; } set { xStart = value; } }
+        public int XStart { get; set; }
+
         /// <summary>
         /// Gets or sets the horizontal center coordinate.
         /// </summary>
         /// <value>The X center coordinate.</value>
-        public int XCenter { get { return xCenter; } set { xCenter = value; } }
+        public int XCenter { get; set; }
+
         /// <summary>
         /// Gets or sets the horizontal right end coordinate.
         /// </summary>
         /// <value>The X end coordinate.</value>
-        public int XEnd { get { return xEnd; } set { xEnd = value; } }
+        public int XEnd { get; set; }
 
         /// <summary>
         /// Gets or sets the vertical top start coordinate.
         /// </summary>
         /// <value>The Y start coordinate.</value>
-        public int YStart { get { return yStart; } set { yStart = value; } }
+        public int YStart { get; set; }
+
         /// <summary>
         /// Gets or sets the vertical center coordinate.
         /// </summary>
         /// <value>The Y center coordinate.</value>
-        public int YCenter { get { return yCenter; } set { yCenter = value; } }
+        public int YCenter { get; set; }
+
         /// <summary>
         /// Gets or sets the vertical bottom end coordinate.
         /// </summary>
         /// <value>The Y end coordinate.</value>
-        public int YEnd { get { return yEnd; } set { yEnd = value; } }
+        public int YEnd { get; set; }
+
         #endregion
 
         #region Helper method
@@ -123,29 +122,28 @@ namespace SeaChart {
         /// <value>The Britannia chart.</value>
         public static Chart Britannia {
             get {
-                Chart chart = new Chart();
+                return new Chart {
+                    Name = "Britannia",
+                    Image = Resources.BritanniaChart,
 
-                chart.Name = "Britannia";
-                chart.image = Resources.BritanniaChart;
+                    map = new List<int> {
+                        0, // Felucca
+                        1, // Trammel
+                    },
 
-                chart.map = new List<int>();
-                chart.map.Add(0); //Felucca
-                chart.map.Add(1); //Trammel
+                    XWidth = 5120, //after it's donj, lost worlds or ML areas
+                    YHeight = 4096,
+                    XZero = 1323,
+                    YZero = 1624,
 
-                chart.xWidth = 5120; //after it's donj, lost worlds or ML areas
-                chart.yHeight = 4096;
-                chart.xZero = 1323;
-                chart.yZero = 1624;
+                    XStart = 3,
+                    XCenter = 325,
+                    XEnd = 642,
 
-                chart.xStart = 3;
-                chart.xCenter = 325;
-                chart.xEnd = 642;
-
-                chart.yStart = 4;
-                chart.yCenter = 261;
-                chart.yEnd = 513;
-                
-                return chart;
+                    YStart = 4,
+                    YCenter = 261,
+                    YEnd = 513
+                };
             }
         }
         #endregion

--- a/Helpers classes/MainOptions.cs
+++ b/Helpers classes/MainOptions.cs
@@ -43,7 +43,7 @@ namespace SeaChart {
         public static MainOptions CreateNewOptionsFile (string optionsFile) {
             //Gets the directory, and create it if it doesn't exist yet
             string directoryName = Path.GetDirectoryName(DefaultOptionsFile);
-            if (directoryName != "" && !Directory.Exists(directoryName)) {
+            if (!string.IsNullOrEmpty(directoryName) && !Directory.Exists(directoryName)) {
                 Directory.CreateDirectory(directoryName);
             }
             //Returns a new instance of the class, and serializes it into the specified XML file.
@@ -87,16 +87,14 @@ namespace SeaChart {
             }
 
             //If the file doesn't exist or contains error, create a new one.
-            if (options == null) options = CreateNewOptionsFile(optionsFile);
-
-            return options;
+            return options ?? CreateNewOptionsFile(optionsFile);
         }
 
         /// <summary>
         /// Saves this instance, serializing it into the default options file.
         /// </summary>
         public void Save () {
-            this.Save(DefaultOptionsFile);
+            Save(DefaultOptionsFile);
         }
 
         /// <summary>
@@ -109,7 +107,7 @@ namespace SeaChart {
 
             //Serializes the class
             XmlSerializer serializer = new XmlSerializer(GetType());
-            serializer.Serialize((TextWriter)writer, this);
+            serializer.Serialize(writer, this);
 
             //Clears all buffers for the current writer and causes any buffered data to
             //be written to the underlying stream and closes the file stream.

--- a/Helpers classes/SerializableDictionary.cs
+++ b/Helpers classes/SerializableDictionary.cs
@@ -22,7 +22,7 @@ namespace System.Collections.Generic {
         /// <summary>
         /// Initializes a new instance of the <see cref="SerializableDictionary&lt;TKey, TValue&gt;"/> class.
         /// </summary>
-        public SerializableDictionary () : base() { }
+        public SerializableDictionary () { }
         /// <summary>
         /// Initializes a new instance of the <see cref="SerializableDictionary&lt;TKey, TValue&gt;"/> class.
         /// </summary>
@@ -36,7 +36,7 @@ namespace System.Collections.Generic {
         /// <returns>
         /// An <see cref="T:System.Xml.Schema.XmlSchema"/> that describes the XML representation of the object that is produced by the <see cref="M:System.Xml.Serialization.IXmlSerializable.WriteXml(System.Xml.XmlWriter)"/> method and consumed by the <see cref="M:System.Xml.Serialization.IXmlSerializable.ReadXml(System.Xml.XmlReader)"/> method.
         /// </returns>
-        public System.Xml.Schema.XmlSchema GetSchema () {
+        public XmlSchema GetSchema () {
             return null;
         }
 
@@ -55,7 +55,7 @@ namespace System.Collections.Generic {
             if (wasEmpty)
                 return;
 
-            while (reader.NodeType != System.Xml.XmlNodeType.EndElement) {
+            while (reader.NodeType != XmlNodeType.EndElement) {
                 reader.ReadStartElement("item");
                 reader.ReadStartElement("key");
                 TKey key = (TKey)keySerializer.Deserialize(reader);
@@ -63,7 +63,7 @@ namespace System.Collections.Generic {
                 reader.ReadStartElement("value");
                 TValue value = (TValue)valueSerializer.Deserialize(reader);
                 reader.ReadEndElement();
-                this.Add(key, value);
+                Add(key, value);
                 reader.ReadEndElement();
                 reader.MoveToContent();
             }


### PR DESCRIPTION
Use auto properties and object initiliation.

Cleanup code to avoid redundant parentheses or extraneous calls to
base. or this.